### PR TITLE
Add the ability to use a context.xml inside of the META-INF folder

### DIFF
--- a/src/main/java/com/github/sahara3/gradle/tomcat/TomcatLauncher.java
+++ b/src/main/java/com/github/sahara3/gradle/tomcat/TomcatLauncher.java
@@ -60,6 +60,8 @@ public class TomcatLauncher {
         this.tomcat = new Tomcat();
         this.tomcat.setPort(this.port);
         this.tomcat.setBaseDir(this.baseDir);
+        // Allow to use a context file inside the META-INF folder
+        this.tomcat.enableNaming();
 
         this.configureServer(this.tomcat.getServer());
         this.configureHost((StandardHost) this.tomcat.getHost());


### PR DESCRIPTION
I was getting an error when I was using a context.xml and in my code I was using the IntitalContextFactory and there was an error regarding the JNDI this one simple change fixes that error

"Need to specify class name in environment or system property, or in an application resource file: java.naming.factory.initial" <- The error message I was getting